### PR TITLE
better error message when connecting to self

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,7 +5,8 @@ import (
 )
 
 var (
-	errInvalidListenIP   = errors.New("invalid ListenIP")
-	errNilStream         = errors.New("stream is nil")
-	errFailedToBootstrap = errors.New("failed to bootstrap to any bootnode")
+	errInvalidListenIP     = errors.New("invalid ListenIP")
+	errNilStream           = errors.New("stream is nil")
+	errFailedToBootstrap   = errors.New("failed to bootstrap to any bootnode")
+	errCannotConnectToSelf = errors.New("cannot connect to self")
 )

--- a/host.go
+++ b/host.go
@@ -284,6 +284,9 @@ func (h *Host) Connectedness(who peer.ID) libp2pnetwork.Connectedness {
 
 // Connect connects to the given peer.
 func (h *Host) Connect(ctx context.Context, who peer.AddrInfo) error {
+	if who.ID == h.PeerID() {
+		return errCannotConnectToSelf
+	}
 	return h.h.Connect(ctx, who)
 }
 

--- a/host_test.go
+++ b/host_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,4 +81,13 @@ func TestAdvertiseDiscover(t *testing.T) {
 		require.Len(t, peerIDs, 1)
 		require.Equal(t, h1.PeerID(), peerIDs[0])
 	}
+}
+
+func TestHost_ConnectToSelf(t *testing.T) {
+	h := newHost(t, basicTestConfig(t))
+	err := h.Start()
+	require.NoError(t, err)
+
+	err = h.Connect(context.Background(), peer.AddrInfo{ID: h.PeerID()})
+	require.ErrorIs(t, err, errCannotConnectToSelf)
 }


### PR DESCRIPTION
If you have multiple swapd daemons, it is easy to accidentally take an offer or query your own daemon. The error message is confusing, as it says `failed to find peers: failed to find any peer in table`. The error is coming from `Connect`, so that is where I put the fix.