### PR TITLE
added goroutine leak detector to TestNewHost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/athanorlabs/go-p2p-net
 go 1.19
 
 require (
+	github.com/fortytw2/leaktest v1.3.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-log v1.0.5
 	github.com/libp2p/go-libp2p v0.26.2

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=

--- a/host_test.go
+++ b/host_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
@@ -20,8 +21,12 @@ func init() {
 func basicTestConfig(t *testing.T, namespaces []string) *Config {
 	// t.TempDir() is unique on every call. Don't reuse this config with multiple hosts.
 	tmpDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	return &Config{
-		Ctx:       context.Background(),
+		Ctx:       ctx,
 		DataDir:   tmpDir,
 		Port:      0, // OS randomized libp2p port
 		KeyFile:   path.Join(tmpDir, "node.key"),
@@ -44,6 +49,7 @@ func newHost(t *testing.T, cfg *Config) *Host {
 }
 
 func TestNewHost(t *testing.T) {
+	t.Cleanup(leaktest.Check(t))
 	h := newHost(t, basicTestConfig(t, []string{""}))
 	err := h.Start()
 	require.NoError(t, err)


### PR DESCRIPTION
Right now these code changes just demonstrate the problem. I added a goroutine leak detector to `NewHost`. If you run `TestNewHost`, you'll see the following leaked goroutines which still existed a full 5 seconds after h.Stop() was called:
```
    leaktest.go:150: leaktest: leaked goroutine: goroutine 46 [IO wait]:
        internal/poll.runtime_pollWait(0x7fbfbc45ccf8, 0x72)
        	/snap/go/10138/src/runtime/netpoll.go:305 +0x89
        internal/poll.(*pollDesc).wait(0xc0000c0780?, 0xc000488160?, 0x0)
        	/snap/go/10138/src/internal/poll/fd_poll_runtime.go:84 +0x32
        internal/poll.(*pollDesc).waitRead(...)
        	/snap/go/10138/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).ReadFromInet4(0xc0000c0780, {0xc000488160, 0x10, 0x10}, 0x4a69c5?)
        	/snap/go/10138/src/internal/poll/fd_unix.go:250 +0x1e5
        net.(*netFD).readFromInet4(0xc0000c0780, {0xc000488160?, 0xc0000c0780?, 0xc0004880dc?}, 0x7fbfbc45cd00?)
        	/snap/go/10138/src/net/fd_posix.go:66 +0x29
        net.(*UDPConn).readFrom(0xc00023ad98?, {0xc000488160?, 0xc0000c0780?, 0xc0004880dc?}, 0xc00023ae58)
        	/snap/go/10138/src/net/udpsock_posix.go:52 +0x1b8
        net.(*UDPConn).readFromUDP(0xc000486030, {0xc000488160?, 0x20e8840?, 0x20e8840?}, 0x0?)
        	/snap/go/10138/src/net/udpsock.go:149 +0x31
        net.(*UDPConn).ReadFromUDP(...)
        	/snap/go/10138/src/net/udpsock.go:141
        github.com/jackpal/go-nat-pmp.(*network).call(0xc000128270, {0xc0004880dc, 0x2, 0x2}, 0x0)
        	/home/dh/go/pkg/mod/github.com/jackpal/go-nat-pmp@v1.0.2/network.go:54 +0x38e
        github.com/jackpal/go-nat-pmp.(*Client).rpc(0x18?, {0xc0004880dc, 0x2, 0x2}, 0xc00043a108?)
        	/home/dh/go/pkg/mod/github.com/jackpal/go-nat-pmp@v1.0.2/natpmp.go:108 +0x46
        github.com/jackpal/go-nat-pmp.(*Client).GetExternalAddress(0xc0004a2fd0?)
        	/home/dh/go/pkg/mod/github.com/jackpal/go-nat-pmp@v1.0.2/natpmp.go:58 +0x50
        github.com/libp2p/go-nat.discoverNATPMPWithAddr.func1()
        	/home/dh/go/pkg/mod/github.com/libp2p/go-nat@v0.1.0/natpmp.go:44 +0x106
        created by github.com/libp2p/go-nat.discoverNATPMPWithAddr
        	/home/dh/go/pkg/mod/github.com/libp2p/go-nat@v0.1.0/natpmp.go:41 +0xae

    leaktest.go:150: leaktest: leaked goroutine: goroutine 102 [select]:
        github.com/libp2p/go-libp2p/p2p/transport/quicreuse.(*reuse).gc(0xc00028b640)
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:110 +0x119
        created by github.com/libp2p/go-libp2p/p2p/transport/quicreuse.newReuse
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:88 +0x110

    leaktest.go:150: leaktest: leaked goroutine: goroutine 103 [select]:
        github.com/libp2p/go-libp2p/p2p/transport/quicreuse.(*reuse).gc(0xc00028b680)
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:110 +0x119
        created by github.com/libp2p/go-libp2p/p2p/transport/quicreuse.newReuse
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:88 +0x110

    leaktest.go:150: leaktest: leaked goroutine: goroutine 108 [IO wait]:
        internal/poll.runtime_pollWait(0x7fbfbc45cb18, 0x72)
        	/snap/go/10138/src/runtime/netpoll.go:305 +0x89
        internal/poll.(*pollDesc).wait(0xc000568c00?, 0xc0004bbc01?, 0x0)
        	/snap/go/10138/src/internal/poll/fd_poll_runtime.go:84 +0x32
        internal/poll.(*pollDesc).waitRead(...)
        	/snap/go/10138/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).RawRead(0xc000568c00, 0xc00028e040)
        	/snap/go/10138/src/internal/poll/fd_unix.go:766 +0x145
        net.(*rawConn).Read(0xc000015720, 0x203000?)
        	/snap/go/10138/src/net/rawconn.go:43 +0x45
        golang.org/x/net/internal/socket.(*syscaller).recvmmsg(0xc0004c4048, {0x1638ae0?, 0xc000015720?}, {0xc0004c6000?, 0x14a0b70?, 0x0?}, 0x40f7bf?)
        	/home/dh/go/pkg/mod/golang.org/x/net@v0.8.0/internal/socket/mmsghdr_unix.go:121 +0x94
        golang.org/x/net/internal/socket.(*Conn).recvMsgs(0xc000390000, {0xc000175080?, 0x8, 0x8}, 0xc0004c2c00?)
        	/home/dh/go/pkg/mod/golang.org/x/net@v0.8.0/internal/socket/rawconn_mmsg.go:25 +0x185
        golang.org/x/net/internal/socket.(*Conn).RecvMsgs(...)
        	/home/dh/go/pkg/mod/golang.org/x/net@v0.8.0/internal/socket/socket.go:267
        golang.org/x/net/ipv4.(*payloadHandler).ReadBatch(0xc00037a790, {0xc000175080?, 0x0?, 0x0?}, 0x0?)
        	/home/dh/go/pkg/mod/golang.org/x/net@v0.8.0/ipv4/batch.go:80 +0x57
        github.com/quic-go/quic-go.(*oobConn).ReadPacket(0xc000569a00)
        	/home/dh/go/pkg/mod/github.com/quic-go/quic-go@v0.33.0/sys_conn_oob.go:154 +0x695
        github.com/quic-go/quic-go.(*packetHandlerMap).listen(0xc0005531e0)
        	/home/dh/go/pkg/mod/github.com/quic-go/quic-go@v0.33.0/packet_handler_map.go:364 +0x70
        created by github.com/quic-go/quic-go.newPacketHandlerMap
        	/home/dh/go/pkg/mod/github.com/quic-go/quic-go@v0.33.0/packet_handler_map.go:142 +0x35d

    leaktest.go:150: leaktest: leaked goroutine: goroutine 109 [select]:
        github.com/quic-go/quic-go.(*packetHandlerMap).runCloseQueue(0xc0005531e0)
        	/home/dh/go/pkg/mod/github.com/quic-go/quic-go@v0.33.0/packet_handler_map.go:277 +0x14e
        created by github.com/quic-go/quic-go.newPacketHandlerMap
        	/home/dh/go/pkg/mod/github.com/quic-go/quic-go@v0.33.0/packet_handler_map.go:143 +0x39a

    leaktest.go:150: leaktest: leaked goroutine: goroutine 119 [select]:
        github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem.(*memoryAddrBook).background(0xc000420400, {0x1639ed8, 0xc00037e440})
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/host/peerstore/pstoremem/addr_book.go:116 +0x12c
        created by github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem.NewAddrBook
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/host/peerstore/pstoremem/addr_book.go:96 +0x265

    leaktest.go:150: leaktest: leaked goroutine: goroutine 120 [select]:
        github.com/libp2p/go-libp2p/p2p/net/swarm.(*DialBackoff).background(0x0?, {0x1639ed8, 0xc00037e480})
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/net/swarm/swarm_dial.go:129 +0xea
        created by github.com/libp2p/go-libp2p/p2p/net/swarm.(*DialBackoff).init
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/net/swarm/swarm_dial.go:122 +0xc5

    leaktest.go:150: leaktest: leaked goroutine: goroutine 126 [select]:
        github.com/libp2p/go-libp2p/p2p/transport/quicreuse.(*reuse).gc(0xc0003d7240)
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:110 +0x119
        created by github.com/libp2p/go-libp2p/p2p/transport/quicreuse.newReuse
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:88 +0x110

    leaktest.go:150: leaktest: leaked goroutine: goroutine 127 [select]:
        github.com/libp2p/go-libp2p/p2p/transport/quicreuse.(*reuse).gc(0xc0003d7280)
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:110 +0x119
        created by github.com/libp2p/go-libp2p/p2p/transport/quicreuse.newReuse
        	/home/dh/go/pkg/mod/github.com/libp2p/go-libp2p@v0.26.2/p2p/transport/quicreuse/reuse.go:88 +0x110
```
I'm not clear if we are doing something wrong, or if it is just the `go-libp2p` libraries that are leaky.